### PR TITLE
Fix Vite proxy path for backend API

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,7 +6,11 @@ export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      '/api': 'http://localhost:7001',
+      '/api': {
+        target: 'http://localhost:7001',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
     },
   },
 })


### PR DESCRIPTION
## Summary
- Rewrite `/api` proxy path to match backend routes

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run lint`
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b77f8f5dfc832db959f37500accb86