### PR TITLE
Fix Vite proxy path and backend exec plugin

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,7 +6,11 @@ export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      '/api': 'http://localhost:7001',
+      '/api': {
+        target: 'http://localhost:7001',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
     },
   },
 })

--- a/java/README.md
+++ b/java/README.md
@@ -1,3 +1,14 @@
 # Java Token Server
 
 This module provides a REST API for managing token counts.
+
+## Running the server
+
+From the repository root:
+
+```bash
+cd java
+mvn exec:java
+```
+
+The server starts on http://localhost:7001 and reads its data from `tokens.txt` in the repository root.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -23,4 +23,17 @@
     <version>5.6.1</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <mainClass>com.codxp.tokens.TokenServer</mainClass>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
## Summary
- Rewrite `/api` proxy path to match backend routes
- Configure Maven exec plugin and document backend startup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b77f8f5dfc832db959f37500accb86