### PR TITLE
fix: resolve token file path for java tools

### DIFF
--- a/java/src/main/java/com/codxp/tokens/Main.java
+++ b/java/src/main/java/com/codxp/tokens/Main.java
@@ -6,7 +6,15 @@ import java.nio.file.*;
 import java.util.*;
 
 public class Main {
-    static final String FILENAME = "../tokens.txt";
+    static final String FILENAME = resolveTokensFile();
+
+    private static String resolveTokensFile() {
+        Path p = Paths.get("tokens.txt");
+        if (!Files.exists(p)) {
+            p = Paths.get("../tokens.txt");
+        }
+        return p.toString();
+    }
 
     static final String RESET = "\u001B[0m";
     static final String BOLD = "\u001B[1m";

--- a/java/src/main/java/com/codxp/tokens/TokenServer.java
+++ b/java/src/main/java/com/codxp/tokens/TokenServer.java
@@ -5,10 +5,19 @@ import io.javalin.http.HttpStatus;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.nio.file.*;
 import java.util.*;
 
 public class TokenServer {
-    private static final String FILENAME = "../tokens.txt";
+    private static final String FILENAME = resolveTokensFile();
+
+    private static String resolveTokensFile() {
+        Path p = Paths.get("tokens.txt");
+        if (!Files.exists(p)) {
+            p = Paths.get("../tokens.txt");
+        }
+        return p.toString();
+    }
 
     public static void main(String[] args) {
         ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
## Summary
- make Java CLI and server locate `tokens.txt` reliably from current or parent directory

## Testing
- `mvn -q test` *(fails: PluginResolutionException, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b794e441e4832db38f110cc2162867