### PR TITLE
feat: add interactive token editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ curl http://localhost:7001/tokens
 ## React Frontend
 
 A Vite-powered React app displays token counts and automatically refreshes every
-five seconds.
+five seconds. Adjust counts with the `+`/`-` buttons and click **Save** to write
+changes back to `tokens.txt`. Auto-refresh is paused while you have unsaved edits.
 
 1. Enter the frontend folder and install dependencies:
    ```bash

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,7 +2,9 @@
 
 This directory contains a minimal React application powered by Vite. It fetches
 XP token data from the backend server and displays the totals for each category.
-The app automatically refreshes token counts every 5 seconds.
+The app automatically refreshes token counts every 5 seconds when there are no
+unsaved edits. Adjust token values with the `+`/`-` buttons and click **Save** to
+persist changes.
 
 ## Development
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -40,3 +40,19 @@
 .read-the-docs {
   color: #888;
 }
+
+.app-title {
+  color: #ff5555;
+}
+
+.title-regular {
+  color: #00ff00;
+}
+
+.title-weapon {
+  color: #0000ff;
+}
+
+.title-battlepass {
+  color: #ff8700;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,8 +6,11 @@ const minutes = [15, 30, 45, 60]
 function App() {
   const [tokens, setTokens] = useState(null)
   const [error, setError] = useState(null)
+  const [dirty, setDirty] = useState(false)
 
   useEffect(() => {
+    if (dirty) return
+
     const fetchTokens = () => {
       fetch('/api/tokens')
         .then((res) => {
@@ -21,7 +24,7 @@ function App() {
     fetchTokens()
     const id = setInterval(fetchTokens, 5000)
     return () => clearInterval(id)
-  }, [])
+  }, [dirty])
 
   const adjustToken = (category, idx, delta) => {
     const current = tokens[category][idx]
@@ -31,11 +34,20 @@ function App() {
       [category]: tokens[category].map((c, i) => (i === idx ? updatedCount : c)),
     }
     setTokens(updatedTokens)
+    setDirty(true)
+  }
+
+  const saveTokens = () => {
     fetch('/api/tokens', {
-      method: 'POST',
+      method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(updatedTokens),
-    }).catch(() => {})
+      body: JSON.stringify(tokens),
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        setDirty(false)
+      })
+      .catch((err) => setError(err.message))
   }
 
   if (error) {
@@ -49,6 +61,9 @@ function App() {
   return (
     <>
       <h1>2XP Tokens</h1>
+      <button onClick={saveTokens} disabled={!dirty}>
+        Save
+      </button>
       {Object.entries(tokens).map(([category, counts]) => (
         <div key={category}>
           <h2>{category}</h2>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -86,7 +86,7 @@ function App() {
 
   return (
     <>
-      <h1>2XP Tokens</h1>
+      <h1 className="app-title">2XP Tokens</h1>
       <div>
         <button onClick={saveTokens} disabled={!dirty}>
           Save
@@ -104,7 +104,7 @@ function App() {
       </div>
       {Object.entries(tokens).map(([category, counts]) => (
         <div key={category}>
-          <h2>{category}</h2>
+          <h2 className={`title-${category}`}>{category}</h2>
           <ul>
             {counts.map((count, idx) => (
               <li key={idx}>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ function App() {
   const [tokens, setTokens] = useState(null)
   const [error, setError] = useState(null)
   const [dirty, setDirty] = useState(false)
+  const [theme, setTheme] = useState('light')
 
   useEffect(() => {
     if (dirty) return
@@ -26,6 +27,10 @@ function App() {
     return () => clearInterval(id)
   }, [dirty])
 
+  useEffect(() => {
+    document.documentElement.className = theme
+  }, [theme])
+
   const adjustToken = (category, idx, delta) => {
     const current = tokens[category][idx]
     const updatedCount = Math.max(0, current + delta)
@@ -34,6 +39,27 @@ function App() {
       [category]: tokens[category].map((c, i) => (i === idx ? updatedCount : c)),
     }
     setTokens(updatedTokens)
+    setDirty(true)
+  }
+
+  const setToken = (category, idx) => {
+    const input = prompt('Enter number:', tokens[category][idx])
+    if (input === null) return
+    const parsed = Math.max(0, parseInt(input, 10))
+    if (isNaN(parsed)) return
+    const updatedTokens = {
+      ...tokens,
+      [category]: tokens[category].map((c, i) => (i === idx ? parsed : c)),
+    }
+    setTokens(updatedTokens)
+    setDirty(true)
+  }
+
+  const resetTokens = () => {
+    const reset = Object.fromEntries(
+      Object.keys(tokens).map((k) => [k, tokens[k].map(() => 0)])
+    )
+    setTokens(reset)
     setDirty(true)
   }
 
@@ -61,9 +87,21 @@ function App() {
   return (
     <>
       <h1>2XP Tokens</h1>
-      <button onClick={saveTokens} disabled={!dirty}>
-        Save
-      </button>
+      <div>
+        <button onClick={saveTokens} disabled={!dirty}>
+          Save
+        </button>
+        <button onClick={resetTokens}>
+          Reset All
+        </button>
+        <label>
+          Theme:
+          <select value={theme} onChange={(e) => setTheme(e.target.value)}>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+      </div>
       {Object.entries(tokens).map(([category, counts]) => (
         <div key={category}>
           <h2>{category}</h2>
@@ -73,6 +111,7 @@ function App() {
                 {minutes[idx]} min: {count}{' '}
                 <button onClick={() => adjustToken(category, idx, -1)}>-</button>
                 <button onClick={() => adjustToken(category, idx, 1)}>+</button>
+                <button onClick={() => setToken(category, idx)}>Enter Number</button>
               </li>
             ))}
           </ul>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 import './App.css'
 
+const minutes = [15, 30, 45, 60]
+
 function App() {
   const [tokens, setTokens] = useState(null)
   const [error, setError] = useState(null)
@@ -21,6 +23,21 @@ function App() {
     return () => clearInterval(id)
   }, [])
 
+  const adjustToken = (category, idx, delta) => {
+    const current = tokens[category][idx]
+    const updatedCount = Math.max(0, current + delta)
+    const updatedTokens = {
+      ...tokens,
+      [category]: tokens[category].map((c, i) => (i === idx ? updatedCount : c)),
+    }
+    setTokens(updatedTokens)
+    fetch('/api/tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(updatedTokens),
+    }).catch(() => {})
+  }
+
   if (error) {
     return <p>Failed to load: {error}</p>
   }
@@ -28,8 +45,6 @@ function App() {
   if (!tokens) {
     return <p>Loading...</p>
   }
-
-  const minutes = [15, 30, 45, 60]
 
   return (
     <>
@@ -39,7 +54,11 @@ function App() {
           <h2>{category}</h2>
           <ul>
             {counts.map((count, idx) => (
-              <li key={idx}>{minutes[idx]} min: {count}</li>
+              <li key={idx}>
+                {minutes[idx]} min: {count}{' '}
+                <button onClick={() => adjustToken(category, idx, -1)}>-</button>
+                <button onClick={() => adjustToken(category, idx, 1)}>+</button>
+              </li>
             ))}
           </ul>
         </div>
@@ -49,3 +68,4 @@ function App() {
 }
 
 export default App
+

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,13 +4,21 @@
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+html.light {
+  color: #213547;
+  background-color: #ffffff;
+}
+
+html.dark {
+  color: rgba(255, 255, 255, 0.87);
+  background-color: #242424;
 }
 
 a {
@@ -42,7 +50,6 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
   cursor: pointer;
   transition: border-color 0.25s;
 }
@@ -54,6 +61,14 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
+html.light button {
+  background-color: #f9f9f9;
+}
+
+html.dark button {
+  background-color: #1a1a1a;
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;
@@ -61,8 +76,5 @@ button:focus-visible {
   }
   a:hover {
     color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -63,10 +63,12 @@ button:focus-visible {
 
 html.light button {
   background-color: #f9f9f9;
+  color: #000000;
 }
 
 html.dark button {
   background-color: #1a1a1a;
+  color: #ffffff;
 }
 
 @media (prefers-color-scheme: light) {


### PR DESCRIPTION
## Summary
- add plus/minus controls to adjust token counts
- send updated token data to backend via POST requests

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8398e05a0832d86425c8cfab83aef