### PR TITLE
feat(frontend): add save button and pause polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ curl http://localhost:7001/tokens
 
 ## React Frontend
 
-A Vite-powered React app displays token counts and automatically refreshes every
-five seconds.
+A Vite-powered React app displays and edits token counts. It refreshes data every
+five seconds, but polling pauses while you are making edits so local changes are
+not overwritten. Use the on-screen **Save** button to persist your updates back
+to `tokens.txt`.
 
 1. Enter the frontend folder and install dependencies:
    ```bash

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,7 +2,10 @@
 
 This directory contains a minimal React application powered by Vite. It fetches
 XP token data from the backend server and displays the totals for each category.
-The app automatically refreshes token counts every 5 seconds.
+You can adjust the numbers with plus/minus controls and persist them with the
+**Save** button. The app automatically refreshes token counts every 5 seconds,
+but polling stops while you are editing so your in-progress changes are not
+overwritten.
 
 ## Development
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,25 +1,32 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import './App.css'
 
 function App() {
   const [tokens, setTokens] = useState(null)
   const [error, setError] = useState(null)
+  const [editing, setEditing] = useState(false)
+  const editingRef = useRef(false)
 
   useEffect(() => {
-    const fetchTokens = () => {
-      fetch('/api/tokens')
-        .then((res) => {
-          if (!res.ok) throw new Error(`HTTP ${res.status}`)
-          return res.json()
-        })
-        .then((data) => setTokens(data))
-        .catch((err) => setError(err.message))
-    }
+    editingRef.current = editing
+  }, [editing])
 
+  const fetchTokens = useCallback(() => {
+    if (editingRef.current) return
+    fetch('/api/tokens')
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        return res.json()
+      })
+      .then((data) => setTokens(data))
+      .catch((err) => setError(err.message))
+  }, [])
+
+  useEffect(() => {
     fetchTokens()
     const id = setInterval(fetchTokens, 5000)
     return () => clearInterval(id)
-  }, [])
+  }, [fetchTokens])
 
   if (error) {
     return <p>Failed to load: {error}</p>
@@ -31,6 +38,30 @@ function App() {
 
   const minutes = [15, 30, 45, 60]
 
+  const updateToken = (category, idx, delta) => {
+    setTokens((prev) => {
+      const next = { ...prev }
+      const arr = [...next[category]]
+      arr[idx] = Math.max(0, arr[idx] + delta)
+      next[category] = arr
+      return next
+    })
+    setEditing(true)
+  }
+
+  const handleSave = () => {
+    fetch('/api/tokens', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(tokens),
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        setEditing(false)
+      })
+      .catch((err) => setError(err.message))
+  }
+
   return (
     <>
       <h1>2XP Tokens</h1>
@@ -39,11 +70,17 @@ function App() {
           <h2>{category}</h2>
           <ul>
             {counts.map((count, idx) => (
-              <li key={idx}>{minutes[idx]} min: {count}</li>
+              <li key={idx}>
+                {minutes[idx]} min:
+                <button onClick={() => updateToken(category, idx, -1)}>-</button>
+                {count}
+                <button onClick={() => updateToken(category, idx, 1)}>+</button>
+              </li>
             ))}
           </ul>
         </div>
       ))}
+      {editing && <button onClick={handleSave}>Save</button>}
     </>
   )
 }


### PR DESCRIPTION
## Summary
- add client-side editing controls with save button and disable auto-polling during edits
- document save workflow and paused polling in READMEs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b83c1897d4832d8b8087f0e21c4b9e