### PR TITLE
Add token reset, manual entry, and theme toggle

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ function App() {
   const [tokens, setTokens] = useState(null)
   const [error, setError] = useState(null)
   const [dirty, setDirty] = useState(false)
+  const [theme, setTheme] = useState('light')
 
   useEffect(() => {
     if (dirty) return
@@ -26,6 +27,10 @@ function App() {
     return () => clearInterval(id)
   }, [dirty])
 
+  useEffect(() => {
+    document.documentElement.className = theme
+  }, [theme])
+
   const adjustToken = (category, idx, delta) => {
     const current = tokens[category][idx]
     const updatedCount = Math.max(0, current + delta)
@@ -34,6 +39,27 @@ function App() {
       [category]: tokens[category].map((c, i) => (i === idx ? updatedCount : c)),
     }
     setTokens(updatedTokens)
+    setDirty(true)
+  }
+
+  const setToken = (category, idx) => {
+    const input = prompt('Enter number:', tokens[category][idx])
+    if (input === null) return
+    const parsed = Math.max(0, parseInt(input, 10))
+    if (isNaN(parsed)) return
+    const updatedTokens = {
+      ...tokens,
+      [category]: tokens[category].map((c, i) => (i === idx ? parsed : c)),
+    }
+    setTokens(updatedTokens)
+    setDirty(true)
+  }
+
+  const resetTokens = () => {
+    const reset = Object.fromEntries(
+      Object.keys(tokens).map((k) => [k, tokens[k].map(() => 0)])
+    )
+    setTokens(reset)
     setDirty(true)
   }
 
@@ -61,9 +87,21 @@ function App() {
   return (
     <>
       <h1>2XP Tokens</h1>
-      <button onClick={saveTokens} disabled={!dirty}>
-        Save
-      </button>
+      <div>
+        <button onClick={saveTokens} disabled={!dirty}>
+          Save
+        </button>
+        <button onClick={resetTokens}>
+          Reset All
+        </button>
+        <label>
+          Theme:
+          <select value={theme} onChange={(e) => setTheme(e.target.value)}>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+      </div>
       {Object.entries(tokens).map(([category, counts]) => (
         <div key={category}>
           <h2>{category}</h2>
@@ -73,6 +111,7 @@ function App() {
                 {minutes[idx]} min: {count}{' '}
                 <button onClick={() => adjustToken(category, idx, -1)}>-</button>
                 <button onClick={() => adjustToken(category, idx, 1)}>+</button>
+                <button onClick={() => setToken(category, idx)}>Enter Number</button>
               </li>
             ))}
           </ul>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,13 +4,21 @@
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+html.light {
+  color: #213547;
+  background-color: #ffffff;
+}
+
+html.dark {
+  color: rgba(255, 255, 255, 0.87);
+  background-color: #242424;
 }
 
 a {
@@ -42,7 +50,6 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
   cursor: pointer;
   transition: border-color 0.25s;
 }
@@ -54,6 +61,14 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
+html.light button {
+  background-color: #f9f9f9;
+}
+
+html.dark button {
+  background-color: #1a1a1a;
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;
@@ -61,8 +76,5 @@ button:focus-visible {
   }
   a:hover {
     color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
   }
 }


### PR DESCRIPTION
## Summary
- add reset all button to zero out every token count
- allow manual number entry for token counts
- add light/dark theme selector

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8416a013c832da9579aaa9901fd1a