### PR TITLE
style(frontend): color XP headings

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -40,3 +40,19 @@
 .read-the-docs {
   color: #888;
 }
+
+.app-title {
+  color: #ff5555;
+}
+
+.title-regular {
+  color: #00ff00;
+}
+
+.title-weapon {
+  color: #0000ff;
+}
+
+.title-battlepass {
+  color: #ff8700;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -86,7 +86,7 @@ function App() {
 
   return (
     <>
-      <h1>2XP Tokens</h1>
+      <h1 className="app-title">2XP Tokens</h1>
       <div>
         <button onClick={saveTokens} disabled={!dirty}>
           Save
@@ -104,7 +104,7 @@ function App() {
       </div>
       {Object.entries(tokens).map(([category, counts]) => (
         <div key={category}>
-          <h2>{category}</h2>
+          <h2 className={`title-${category}`}>{category}</h2>
           <ul>
             {counts.map((count, idx) => (
               <li key={idx}>


### PR DESCRIPTION
## Summary
- Color main heading and XP category titles to match CLI color scheme
- Add CSS classes for regular, weapon, and battle pass XP colors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b84b379564832da9d1c2187a59b49e