### PR TITLE
Add dynamic XP minute totals

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -51,6 +51,11 @@
   margin-bottom: 1rem;
 }
 
+.grand-total,
+.category-total {
+  margin: 0.25rem 0 1rem;
+}
+
 .category-title {
   display: flex;
   align-items: center;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -85,6 +85,11 @@ function App() {
       .catch((err) => setError(err.message))
   }
 
+  const minutesForCategory = (counts) =>
+    counts.reduce((sum, count, idx) => sum + count * minutes[idx], 0)
+
+  const formatMinutes = (m) => `${Math.floor(m / 60)} Hours (${m} Minutes)`
+
   if (error) {
     return <p>Failed to load: {error}</p>
   }
@@ -93,10 +98,16 @@ function App() {
     return <p>Loading...</p>
   }
 
+  const grandTotal = Object.values(tokens).reduce(
+    (sum, counts) => sum + minutesForCategory(counts),
+    0
+  )
+
   return (
     <>
     <img src={codLogo} alt="Call of Duty logo" className="cod-logo" />
       <h1 className="app-title">2XP Tokens</h1>
+      <p className="grand-total">{formatMinutes(grandTotal)}</p>
       <div>
         <button onClick={saveTokens} disabled={!dirty}>
           Save
@@ -112,7 +123,9 @@ function App() {
           </select>
         </label>
       </div>
-      {Object.entries(tokens).map(([category, counts]) => (
+      {Object.entries(tokens).map(([category, counts]) => {
+        const total = minutesForCategory(counts)
+        return (
         <div key={category}>
           <h2 className={`category-title title-${category}`}>
             <img
@@ -122,6 +135,7 @@ function App() {
             />
             {category.charAt(0).toUpperCase() + category.slice(1)}
           </h2>
+          <p className="category-total">{formatMinutes(total)}</p>
           <ul>
             {counts.map((count, idx) => (
               <li key={idx}>
@@ -133,7 +147,7 @@ function App() {
             ))}
           </ul>
         </div>
-      ))}
+      )})}
     </>
   )
 }


### PR DESCRIPTION
## Summary
- Display running minute totals for each XP token category with hours and minutes
- Show a grand total of all minutes under the main 2XP Tokens title
- Style new totals for consistent spacing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b86b856230832d9ee0393b840b3dc4