### PR TITLE
Display XP categories horizontally

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -79,3 +79,14 @@
 .title-battlepass {
   color: #d89a39;
 }
+
+.categories {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 2rem;
+}
+
+.category {
+  flex: 1;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -128,31 +128,35 @@ function App() {
           </select>
         </label>
       </div>
-      {Object.entries(tokens).map(([category, counts]) => {
-        const total = minutesForCategory(counts)
-        return (
-        <div key={category}>
-          <h2 className={`category-title title-${category}`}>
-            <img
-              src={categoryIcons[category]}
-              alt={`${category} icon`}
-              className="category-icon"
-            />
-            {category.charAt(0).toUpperCase() + category.slice(1)}
-          </h2>
-          <p className="category-total">{formatMinutes(total)}</p>
-          <ul>
-            {counts.map((count, idx) => (
-              <li key={idx}>
-                {minutes[idx]} min: {count}{' '}
-                <button onClick={() => adjustToken(category, idx, -1)}>-</button>
-                <button onClick={() => adjustToken(category, idx, 1)}>+</button>
-                <button onClick={() => setToken(category, idx)}>Enter Number</button>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )})}
+      <div className="categories">
+        {['regular', 'weapon', 'battlepass'].map((category) => {
+          const counts = tokens[category]
+          const total = minutesForCategory(counts)
+          return (
+            <section key={category} className="category">
+              <h2 className={`category-title title-${category}`}>
+                <img
+                  src={categoryIcons[category]}
+                  alt={`${category} icon`}
+                  className="category-icon"
+                />
+                {category.charAt(0).toUpperCase() + category.slice(1)}
+              </h2>
+              <p className="category-total">{formatMinutes(total)}</p>
+              <ul>
+                {counts.map((count, idx) => (
+                  <li key={idx}>
+                    {minutes[idx]} min: {count}{' '}
+                    <button onClick={() => adjustToken(category, idx, -1)}>-</button>
+                    <button onClick={() => adjustToken(category, idx, 1)}>+</button>
+                    <button onClick={() => setToken(category, idx)}>Enter Number</button>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )
+        })}
+      </div>
     </>
   )
 }


### PR DESCRIPTION
## Summary
- Arrange regular, weapon, and battlepass sections side-by-side instead of stacked
- Style categories with flexbox for horizontal layout

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b87047015c832d9d30ee548946d7b5