### PR TITLE
Fix token count alignment

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -90,3 +90,9 @@
 .category {
   flex: 1;
 }
+
+.count {
+  display: inline-block;
+  width: 3ch;
+  text-align: right;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -146,7 +146,7 @@ function App() {
               <ul>
                 {counts.map((count, idx) => (
                   <li key={idx}>
-                    {minutes[idx]} min: {count}{' '}
+                    {minutes[idx]} min: <span className="count">{count}</span>{' '}
                     <button onClick={() => adjustToken(category, idx, -1)}>-</button>
                     <button onClick={() => adjustToken(category, idx, 1)}>+</button>
                     <button onClick={() => setToken(category, idx)}>Enter Number</button>


### PR DESCRIPTION
## Summary
- Keep token counter width fixed for consistent alignment
- Style count with dedicated CSS class

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b873514788832da89d547dd6834405