### PR TITLE
Add macOS startup script

### DIFF
--- a/start-mac.sh
+++ b/start-mac.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+# Launch Java backend and React frontend for CoDXPTokenTracker on macOS.
+# Usage: ./start-mac.sh
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Start the Java backend in the background
+cd "$ROOT_DIR/java"
+mvn exec:java &
+BACK_PID=$!
+
+# Start the frontend
+cd "$ROOT_DIR/frontend"
+npm install
+npm run dev
+
+# When frontend exits, terminate backend
+kill $BACK_PID


### PR DESCRIPTION
## Summary
- add a macOS shell script to launch the Java backend and React frontend together

## Testing
- `mvn -q test` *(fails: plugin resolution exception, network unreachable)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bad56788e4832d82ddf7679293bff1