### PR TITLE
Add startup scripts to README and Windows batch helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ All components share a text file named `tokens.txt` in the repository root. The 
    - JDK 17+ and Apache Maven 3.8+
    - Node.js 20+ and npm 10+
    - (Optional) `pip install colorama` for better Windows terminal colours.
+
+For a one-command startup, use the provided scripts to launch both the backend and frontend:
+
+- macOS: `./start-mac.sh`
+- Windows: `start-windows.bat`
+
 3. **Start the Java backend**
    ```bash
    cd java

--- a/start-mac.sh
+++ b/start-mac.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+# Launch Java backend and React frontend for CoDXPTokenTracker on macOS.
+# Usage: ./start-mac.sh
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Start the Java backend in the background
+cd "$ROOT_DIR/java"
+mvn exec:java &
+BACK_PID=$!
+
+# Start the frontend
+cd "$ROOT_DIR/frontend"
+npm install
+npm run dev
+
+# When frontend exits, terminate backend
+kill $BACK_PID

--- a/start-windows.bat
+++ b/start-windows.bat
@@ -1,0 +1,13 @@
+@echo off
+REM Launch Java backend and React frontend for CoDXPTokenTracker on Windows.
+REM Usage: double-click start-windows.bat
+cd /d "%~dp0"
+
+cd java
+start mvn exec:java
+
+cd ..\frontend
+npm install
+npm run dev
+
+pause


### PR DESCRIPTION
## Summary
- Document quick-start scripts in the README for macOS and Windows
- Add `start-windows.bat` script to launch backend and frontend together

## Testing
- `cd java && mvn -q test` *(Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*
- `cd ../frontend && npm test` *(Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bad56788e4832d82ddf7679293bff1