### PR TITLE
Add user authentication and secure token endpoints

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -18,6 +18,28 @@
       <version>2.16.1</version>
     </dependency>
     <dependency>
+      <groupId>org.mindrot</groupId>
+      <artifactId>jbcrypt</artifactId>
+      <version>0.4</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <version>0.11.5</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>0.11.5</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>0.11.5</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
     <groupId>io.javalin</groupId>
     <artifactId>javalin-bundle</artifactId>
     <version>5.6.1</version>

--- a/java/src/main/java/com/codxp/tokens/UserService.java
+++ b/java/src/main/java/com/codxp/tokens/UserService.java
@@ -1,0 +1,92 @@
+package com.codxp.tokens;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.mindrot.jbcrypt.BCrypt;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.*;
+import java.security.Key;
+import java.util.*;
+
+/**
+ * Simple user management helper providing registration, authentication
+ * and JWT token handling.
+ */
+public class UserService {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String TOKENS_FILE = resolveTokensFile();
+    private static final Key KEY = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+
+    private static Path userFile(String username) {
+        Path base = Paths.get(TOKENS_FILE).getParent();
+        if (base == null) base = Paths.get(".");
+        return base.resolve("data").resolve("users").resolve(username + ".json");
+    }
+
+    public static String resolveTokensFile() {
+        Path p = Paths.get("tokens.txt");
+        if (!Files.exists(p)) {
+            p = Paths.get("../tokens.txt");
+        }
+        return p.toString();
+    }
+
+    public static boolean register(String username, String password) throws IOException {
+        Path userPath = userFile(username);
+        if (Files.exists(userPath)) {
+            return false;
+        }
+        Files.createDirectories(userPath.getParent());
+        String hash = BCrypt.hashpw(password, BCrypt.gensalt());
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("password_hash", hash);
+        Map<String, List<Integer>> tokens = new LinkedHashMap<>();
+        for (TokenCategory cat : TokenCategory.values()) {
+            tokens.put(cat.key(), Arrays.asList(0, 0, 0, 0));
+        }
+        data.put("tokens", tokens);
+        try (OutputStream out = Files.newOutputStream(userPath)) {
+            MAPPER.writerWithDefaultPrettyPrinter().writeValue(out, data);
+        }
+        return true;
+    }
+
+    public static boolean validate(String username, String password) throws IOException {
+        Path userPath = userFile(username);
+        if (!Files.exists(userPath)) {
+            return false;
+        }
+        try (InputStream in = Files.newInputStream(userPath)) {
+            Map<String, Object> obj = MAPPER.readValue(in, new TypeReference<>() {});
+            Object hashObj = obj.get("password_hash");
+            if (!(hashObj instanceof String)) {
+                return false;
+            }
+            String hash = (String) hashObj;
+            return BCrypt.checkpw(password, hash);
+        }
+    }
+
+    public static String issueToken(String username) {
+        return Jwts.builder().setSubject(username).signWith(KEY).compact();
+    }
+
+    public static String verifyToken(String token) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(KEY).build()
+                    .parseClaimsJws(token).getBody().getSubject();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public static String getTokensFile() {
+        return TOKENS_FILE;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce UserService for registration, password hashing, JWT handling and token file resolution
- secure token and totals endpoints with Authorization header and add register/login routes
- include BCrypt and JWT dependencies

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68bf83193634832d95d8e8f8ee8db7e2