### PR TITLE
Return token after user registration

### DIFF
--- a/java/src/main/java/com/codxp/tokens/TokenServer.java
+++ b/java/src/main/java/com/codxp/tokens/TokenServer.java
@@ -47,7 +47,8 @@ public class TokenServer {
             }
             boolean ok = UserService.register(username, password);
             if (ok) {
-                ctx.status(HttpStatus.CREATED);
+                String token = UserService.issueToken(username);
+                ctx.status(HttpStatus.CREATED).json(Map.of("token", token));
             } else {
                 ctx.status(HttpStatus.CONFLICT);
             }


### PR DESCRIPTION
## Summary
- issue JWT token from `/register` and return it to the client

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `mvn -q -e -DskipTests=true package` *(fails: Could not transfer artifact maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8552a138832da9d86e9ec7520eed