### PR TITLE
Handle empty register response

### DIFF
--- a/frontend/src/Register.jsx
+++ b/frontend/src/Register.jsx
@@ -12,15 +12,19 @@ export default function Register({ onAuth, switchToLogin }) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password }),
     })
-      .then((res) => {
+      .then(async (res) => {
         if (!res.ok) throw new Error('Registration failed')
-        return res.json()
+        try {
+          return await res.json()
+        } catch {
+          return {}
+        }
       })
       .then((data) => {
         if (data.token) {
           onAuth(data.token)
         } else {
-          throw new Error('No token returned')
+          switchToLogin()
         }
       })
       .catch((err) => setError(err.message))


### PR DESCRIPTION
## Summary
- Avoid JSON parse errors when registering by safely reading response and falling back to login when no token returned

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf88453e50832daeb0700f40c15f10