### PR TITLE
feat: add account menu with password change

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A small playground for tracking Call of Duty Double XP tokens. The project demon
 - **Java REST API** – HTTP service used by the frontend.
 - **React frontend** – dashboard that consumes the API and lets you adjust counts.
 
+The frontend includes an account menu (top-right icon) where users can change their password or log out.
+
 Tokens are stored per-user as JSON files under `data/users/<username>.json`. Each file contains a hashed password and token counts. If no user file exists, the tools fall back to the legacy `tokens.txt` in the repository root.
 
 ## Setup

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -22,3 +22,4 @@ React app built with Vite that displays and updates XP token counts through the 
 | `npm run lint` | Run ESLint on the source files. |
 
 Use the `+`/`-` buttons in the UI to change counts and **Save** to persist them to `tokens.txt`.
+Click the account icon in the top-right to change your password or log out.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -96,3 +96,68 @@
   width: 3ch;
   text-align: right;
 }
+
+.account-icon {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  width: 32px;
+  height: 32px;
+  cursor: pointer;
+}
+
+.account-menu {
+  position: fixed;
+  top: 4rem;
+  right: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  background: #fff;
+  z-index: 10;
+}
+
+html.dark .account-menu {
+  background: #242424;
+  border-color: #444;
+}
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20;
+}
+
+.change-password-form {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+}
+
+html.dark .change-password-form {
+  background: #1a1a1a;
+}
+
+.change-password-actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+}
+
+.error {
+  color: #ff5555;
+}
+
+.success {
+  color: #388f50;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,8 +5,10 @@ import codLogoDark from './assets/cod-logo2.png'
 import xpRegular from './assets/xp-regular.png'
 import xpWeapon from './assets/xp-weapon.png'
 import xpBattlepass from './assets/xp-battlepass.png'
+import accountIcon from './assets/account.svg'
 import Login from './Login.jsx'
 import Register from './Register.jsx'
+import ChangePassword from './ChangePassword.jsx'
 
 const minutes = [15, 30, 45, 60]
 const categoryIcons = {
@@ -22,6 +24,8 @@ function App() {
   const [theme, setTheme] = useState('dark')
   const [authToken, setAuthToken] = useState(() => localStorage.getItem('token'))
   const [showRegister, setShowRegister] = useState(false)
+  const [showAccountMenu, setShowAccountMenu] = useState(false)
+  const [showChangePassword, setShowChangePassword] = useState(false)
 
   const handleAuth = (t) => {
     localStorage.setItem('token', t)
@@ -150,11 +154,36 @@ function App() {
 
   return (
     <>
-    <img
-      src={theme === 'dark' ? codLogoDark : codLogoLight}
-      alt="Call of Duty logo"
-      className="cod-logo"
-    />
+      <img
+        src={accountIcon}
+        alt="Account"
+        className="account-icon"
+        onClick={() => setShowAccountMenu((m) => !m)}
+      />
+      {showAccountMenu && (
+        <div className="account-menu">
+          <button
+            onClick={() => {
+              setShowChangePassword(true)
+              setShowAccountMenu(false)
+            }}
+          >
+            Change Password
+          </button>
+          <button onClick={logout}>Logout</button>
+        </div>
+      )}
+      {showChangePassword && (
+        <ChangePassword
+          authToken={authToken}
+          onClose={() => setShowChangePassword(false)}
+        />
+      )}
+      <img
+        src={theme === 'dark' ? codLogoDark : codLogoLight}
+        alt="Call of Duty logo"
+        className="cod-logo"
+      />
       <h1 className="app-title">2XP Tokens</h1>
       <p className="grand-total">{formatMinutes(grandTotal)}</p>
       <div>
@@ -162,7 +191,6 @@ function App() {
           Save
         </button>
         <button onClick={resetTokens}>Reset All</button>
-        <button onClick={logout}>Logout</button>
         <label>
           Theme:
           <select value={theme} onChange={(e) => setTheme(e.target.value)}>

--- a/frontend/src/ChangePassword.jsx
+++ b/frontend/src/ChangePassword.jsx
@@ -1,0 +1,66 @@
+import { useState } from 'react'
+
+export default function ChangePassword({ authToken, onClose }) {
+  const [oldPassword, setOldPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [error, setError] = useState(null)
+  const [success, setSuccess] = useState(false)
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    setError(null)
+    setSuccess(false)
+    fetch('/api/change-password', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authToken}`,
+      },
+      body: JSON.stringify({ oldPassword, newPassword }),
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error('Failed to change password')
+        setSuccess(true)
+        setOldPassword('')
+        setNewPassword('')
+      })
+      .catch((err) => setError(err.message))
+  }
+
+  return (
+    <div className="modal">
+      <form onSubmit={handleSubmit} className="change-password-form">
+        <h2>Change Password</h2>
+        {error && <p className="error">{error}</p>}
+        {success && <p className="success">Password updated</p>}
+        <div>
+          <label>
+            Current Password
+            <input
+              type="password"
+              value={oldPassword}
+              onChange={(e) => setOldPassword(e.target.value)}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            New Password
+            <input
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+            />
+          </label>
+        </div>
+        <div className="change-password-actions">
+          <button type="submit">Update</button>
+          <button type="button" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+

--- a/frontend/src/assets/account.svg
+++ b/frontend/src/assets/account.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="12" cy="8" r="4" fill="currentColor"/>
+  <path d="M4 20c0-4 4-6 8-6s8 2 8 6v2H4v-2z" fill="currentColor"/>
+</svg>

--- a/java/src/main/java/com/codxp/tokens/TokenServer.java
+++ b/java/src/main/java/com/codxp/tokens/TokenServer.java
@@ -66,6 +66,25 @@ public class TokenServer {
             }
         });
 
+        app.post("/change-password", ctx -> {
+            String username = ctx.attribute("username");
+            if (username == null) {
+                return;
+            }
+            Map<String, String> body = mapper.readValue(ctx.body(), new TypeReference<>() {});
+            String oldPw = body.get("oldPassword");
+            String newPw = body.get("newPassword");
+            if (oldPw == null || newPw == null) {
+                ctx.status(HttpStatus.BAD_REQUEST);
+                return;
+            }
+            if (UserService.changePassword(username, oldPw, newPw)) {
+                ctx.status(HttpStatus.NO_CONTENT);
+            } else {
+                ctx.status(HttpStatus.UNAUTHORIZED);
+            }
+        });
+
         app.get("/tokens", ctx -> {
             String username = ctx.attribute("username");
             if (username == null) {


### PR DESCRIPTION
## Summary
- add account icon with dropdown menu to change password or log out
- enable password updates via new API endpoint and backend service
- document new account menu in READMEs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8a852954832db575a6eda75db044