### PR TITLE
Improve password change error handling

### DIFF
--- a/frontend/src/ChangePassword.jsx
+++ b/frontend/src/ChangePassword.jsx
@@ -18,8 +18,11 @@ export default function ChangePassword({ authToken, onClose }) {
       },
       body: JSON.stringify({ oldPassword, newPassword }),
     })
-      .then((res) => {
-        if (!res.ok) throw new Error('Failed to change password')
+      .then(async (res) => {
+        if (!res.ok) {
+          const msg = await res.text()
+          throw new Error(msg || 'Failed to change password')
+        }
         setSuccess(true)
         setOldPassword('')
         setNewPassword('')

--- a/java/src/main/java/com/codxp/tokens/TokenServer.java
+++ b/java/src/main/java/com/codxp/tokens/TokenServer.java
@@ -75,13 +75,13 @@ public class TokenServer {
             String oldPw = body.get("oldPassword");
             String newPw = body.get("newPassword");
             if (oldPw == null || newPw == null) {
-                ctx.status(HttpStatus.BAD_REQUEST);
+                ctx.status(HttpStatus.BAD_REQUEST).result("Missing fields");
                 return;
             }
             if (UserService.changePassword(username, oldPw, newPw)) {
                 ctx.status(HttpStatus.NO_CONTENT);
             } else {
-                ctx.status(HttpStatus.UNAUTHORIZED);
+                ctx.status(HttpStatus.UNAUTHORIZED).result("Old password doesn't match");
             }
         });
 


### PR DESCRIPTION
## Summary
- Return descriptive error when old password is incorrect
- Surface backend error message in change-password form

## Testing
- `npm run lint`
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8bd86590832db3d56f8516711078