### PR TITLE
Fix change password endpoint path

### DIFF
--- a/java/src/main/java/com/codxp/tokens/TokenServer.java
+++ b/java/src/main/java/com/codxp/tokens/TokenServer.java
@@ -18,6 +18,25 @@ public class TokenServer {
         return UserService.verifyToken(token);
     }
 
+    private static void handleChangePassword(Context ctx, ObjectMapper mapper) throws Exception {
+        String username = ctx.attribute("username");
+        if (username == null) {
+            return;
+        }
+        Map<String, String> body = mapper.readValue(ctx.body(), new TypeReference<>() {});
+        String oldPw = body.get("oldPassword");
+        String newPw = body.get("newPassword");
+        if (oldPw == null || newPw == null) {
+            ctx.status(HttpStatus.BAD_REQUEST).result("Missing fields");
+            return;
+        }
+        if (UserService.changePassword(username, oldPw, newPw)) {
+            ctx.status(HttpStatus.NO_CONTENT);
+        } else {
+            ctx.status(HttpStatus.UNAUTHORIZED).result("Old password doesn't match");
+        }
+    }
+
     public static void main(String[] args) {
         ObjectMapper mapper = new ObjectMapper();
         Javalin app = Javalin.create(config -> {
@@ -66,24 +85,8 @@ public class TokenServer {
             }
         });
 
-        app.post("/change-password", ctx -> {
-            String username = ctx.attribute("username");
-            if (username == null) {
-                return;
-            }
-            Map<String, String> body = mapper.readValue(ctx.body(), new TypeReference<>() {});
-            String oldPw = body.get("oldPassword");
-            String newPw = body.get("newPassword");
-            if (oldPw == null || newPw == null) {
-                ctx.status(HttpStatus.BAD_REQUEST).result("Missing fields");
-                return;
-            }
-            if (UserService.changePassword(username, oldPw, newPw)) {
-                ctx.status(HttpStatus.NO_CONTENT);
-            } else {
-                ctx.status(HttpStatus.UNAUTHORIZED).result("Old password doesn't match");
-            }
-        });
+        app.post("/change-password", ctx -> handleChangePassword(ctx, mapper));
+        app.post("/api/change-password", ctx -> handleChangePassword(ctx, mapper));
 
         app.get("/tokens", ctx -> {
             String username = ctx.attribute("username");


### PR DESCRIPTION
## Summary
- add reusable password update handler
- support `/api/change-password` route for password updates

## Testing
- `mvn test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8d80d760832d8bf277423083820e