### PR TITLE
Add profile fields and top-bar display

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -127,3 +127,16 @@ html.dark .account-menu {
 .error {
   color: #ff5555;
 }
+
+.user-bar {
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  display: flex;
+  gap: 0.5rem;
+  font-weight: bold;
+}
+
+.user-level.master {
+  color: orange;
+}

--- a/java/src/main/java/com/codxp/tokens/TokenServer.java
+++ b/java/src/main/java/com/codxp/tokens/TokenServer.java
@@ -66,6 +66,37 @@ public class TokenServer {
             }
         });
 
+        app.get("/profile", ctx -> {
+            String username = ctx.attribute("username");
+            if (username == null) {
+                return;
+            }
+            ctx.json(UserService.getProfile(username));
+        });
+
+        app.put("/profile", ctx -> {
+            String username = ctx.attribute("username");
+            if (username == null) {
+                return;
+            }
+            Map<String, Object> in = mapper.readValue(ctx.body(), new TypeReference<>() {});
+            String codName = Objects.toString(in.get("cod_username"), "");
+            String prestige = Objects.toString(in.get("prestige"), "");
+            int level = 1;
+            Object lvlObj = in.get("level");
+            if (lvlObj instanceof Number) {
+                level = ((Number) lvlObj).intValue();
+            } else if (lvlObj instanceof String) {
+                try {
+                    level = Integer.parseInt((String) lvlObj);
+                } catch (NumberFormatException ignored) {
+                }
+            }
+            level = Math.min(1000, Math.max(1, level));
+            UserService.updateProfile(username, codName, prestige, level);
+            ctx.status(HttpStatus.NO_CONTENT);
+        });
+
         app.get("/tokens", ctx -> {
             String username = ctx.attribute("username");
             if (username == null) {

--- a/java/src/main/java/com/codxp/tokens/UserService.java
+++ b/java/src/main/java/com/codxp/tokens/UserService.java
@@ -53,6 +53,10 @@ public class UserService {
             tokens.put(cat.key(), Arrays.asList(0, 0, 0, 0));
         }
         data.put("tokens", tokens);
+        // default profile data
+        data.put("cod_username", "");
+        data.put("prestige", "");
+        data.put("level", 1);
         try (OutputStream out = Files.newOutputStream(userPath)) {
             MAPPER.writerWithDefaultPrettyPrinter().writeValue(out, data);
         }
@@ -95,5 +99,34 @@ public class UserService {
 
     public static String getTokensFile() {
         return TOKENS_FILE;
+    }
+
+    /** Read profile information for the given user. */
+    public static Map<String, Object> getProfile(String username) throws IOException {
+        Path userPath = userFile(username);
+        Map<String, Object> obj;
+        try (InputStream in = Files.newInputStream(userPath)) {
+            obj = MAPPER.readValue(in, new TypeReference<>() {});
+        }
+        Map<String, Object> profile = new LinkedHashMap<>();
+        profile.put("cod_username", obj.getOrDefault("cod_username", ""));
+        profile.put("prestige", obj.getOrDefault("prestige", ""));
+        profile.put("level", obj.getOrDefault("level", 1));
+        return profile;
+    }
+
+    /** Update profile information for the given user. */
+    public static void updateProfile(String username, String codUsername, String prestige, int level) throws IOException {
+        Path userPath = userFile(username);
+        Map<String, Object> obj;
+        try (InputStream in = Files.newInputStream(userPath)) {
+            obj = MAPPER.readValue(in, new TypeReference<>() {});
+        }
+        obj.put("cod_username", codUsername);
+        obj.put("prestige", prestige);
+        obj.put("level", level);
+        try (OutputStream out = Files.newOutputStream(userPath)) {
+            MAPPER.writerWithDefaultPrettyPrinter().writeValue(out, obj);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Persist CoD username, prestige, and level for each account
- Expose `/profile` API endpoints to read and update profile data
- Show editable profile options in account menu and display info in top bar with prestige master coloring

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`
- `mvn -q -f java/pom.xml test` *(fails: Plugin resolution error: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9191006c832dab33c8d5068a9a3b