### PR TITLE
Configure Vercel build to use frontend project

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "framework": "vite",
+  "installCommand": "npm install --prefix frontend",
+  "buildCommand": "npm run build --prefix frontend",
+  "outputDirectory": "frontend/dist",
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/.*", "dest": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Vercel configuration so deployments install and build the frontend workspace and publish its dist folder
- enable single-page-app routing by rewriting unknown routes back to index.html

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cac61909ec832d817cf1d67b719e73