### PR TITLE
Add Vercel API functions for data access

### DIFF
--- a/api/_lib/auth.js
+++ b/api/_lib/auth.js
@@ -1,0 +1,44 @@
+const crypto = require('crypto')
+const jwt = require('jsonwebtoken')
+const { sendStatus } = require('./http')
+
+const SECRET = (() => {
+  if (!global.__CODXP_SECRET) {
+    global.__CODXP_SECRET = crypto.randomBytes(32)
+  }
+  return global.__CODXP_SECRET
+})()
+
+function issueToken(username) {
+  return jwt.sign({ sub: username }, SECRET, { expiresIn: '1h' })
+}
+
+function verifyToken(token) {
+  try {
+    const decoded = jwt.verify(token, SECRET)
+    return decoded && decoded.sub
+  } catch (err) {
+    return null
+  }
+}
+
+function requireUser(req, res) {
+  const auth = req.headers['authorization']
+  if (!auth || typeof auth !== 'string' || !auth.startsWith('Bearer ')) {
+    sendStatus(res, 401, 'Unauthorized')
+    return null
+  }
+  const token = auth.slice('Bearer '.length)
+  const username = verifyToken(token)
+  if (!username) {
+    sendStatus(res, 401, 'Unauthorized')
+    return null
+  }
+  return username
+}
+
+module.exports = {
+  issueToken,
+  verifyToken,
+  requireUser,
+}

--- a/api/_lib/data.js
+++ b/api/_lib/data.js
@@ -1,0 +1,293 @@
+const fs = require('fs/promises')
+const path = require('path')
+const bcrypt = require('bcryptjs')
+
+const CATEGORIES = ['regular', 'weapon', 'battlepass']
+const MINUTE_BUCKETS = [15, 30, 45, 60]
+const DATA_DIR = path.join(process.cwd(), 'data', 'users')
+const LEGACY_FILES = [
+  path.join(process.cwd(), 'tokens.txt'),
+  path.join(process.cwd(), '..', 'tokens.txt'),
+]
+
+const memoryStore = global.__CODXP_USERS || (global.__CODXP_USERS = new Map())
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value))
+}
+
+async function fileExists(filePath) {
+  try {
+    await fs.access(filePath)
+    return true
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return false
+    throw err
+  }
+}
+
+function zeroTokens() {
+  return CATEGORIES.reduce((acc, cat) => {
+    acc[cat] = MINUTE_BUCKETS.map(() => 0)
+    return acc
+  }, {})
+}
+
+function ensureTokenArray(value) {
+  const arr = Array.isArray(value) ? value : []
+  return MINUTE_BUCKETS.map((_, idx) => {
+    const raw = arr[idx]
+    const num = typeof raw === 'number' ? raw : parseInt(raw, 10)
+    if (!Number.isFinite(num) || isNaN(num) || num < 0) {
+      return 0
+    }
+    return Math.floor(num)
+  })
+}
+
+function normalizeTokens(tokens = {}) {
+  const out = {}
+  for (const cat of CATEGORIES) {
+    out[cat] = ensureTokenArray(tokens[cat])
+  }
+  return out
+}
+
+function clampLevel(value) {
+  const num = typeof value === 'number' ? value : parseInt(value, 10)
+  if (!Number.isFinite(num) || isNaN(num)) {
+    return 1
+  }
+  return Math.min(1000, Math.max(1, Math.round(num)))
+}
+
+function normalizeUser(raw = {}) {
+  const tokens = normalizeTokens(raw.tokens)
+  return {
+    password_hash: typeof raw.password_hash === 'string' ? raw.password_hash : '',
+    tokens,
+    cod_username: typeof raw.cod_username === 'string' ? raw.cod_username : '',
+    prestige: typeof raw.prestige === 'string' ? raw.prestige : '',
+    level: clampLevel(raw.level ?? 1),
+  }
+}
+
+async function readLegacyTokens() {
+  for (const candidate of LEGACY_FILES) {
+    try {
+      const contents = await fs.readFile(candidate, 'utf8')
+      const lines = contents.split(/\r?\n/).filter((line) => line.length > 0)
+      const values = []
+      for (const line of lines) {
+        const num = parseInt(line.trim(), 10)
+        values.push(Number.isFinite(num) && !isNaN(num) && num >= 0 ? Math.floor(num) : 0)
+      }
+      while (values.length < 12) {
+        values.push(0)
+      }
+      const tokens = {
+        regular: ensureTokenArray(values.slice(0, 4)),
+        weapon: ensureTokenArray(values.slice(4, 8)),
+        battlepass: ensureTokenArray(values.slice(8, 12)),
+      }
+      return tokens
+    } catch (err) {
+      if (!err || err.code !== 'ENOENT') {
+        throw err
+      }
+    }
+  }
+  return zeroTokens()
+}
+
+async function writeLegacyTokens(tokens) {
+  const payload = []
+  for (const cat of CATEGORIES) {
+    for (const val of ensureTokenArray(tokens[cat])) {
+      payload.push(String(val))
+    }
+  }
+  for (const candidate of LEGACY_FILES) {
+    try {
+      await fs.writeFile(candidate, payload.join('\n') + '\n', 'utf8')
+      return true
+    } catch (err) {
+      if (err && (err.code === 'ENOENT' || err.code === 'EROFS' || err.code === 'EACCES')) {
+        continue
+      }
+      throw err
+    }
+  }
+  return false
+}
+
+async function readUserFile(username) {
+  const userPath = path.join(DATA_DIR, `${username}.json`)
+  try {
+    const contents = await fs.readFile(userPath, 'utf8')
+    return JSON.parse(contents)
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      return null
+    }
+    throw err
+  }
+}
+
+async function loadUser(username) {
+  if (!username) return null
+  if (memoryStore.has(username)) {
+    return clone(memoryStore.get(username))
+  }
+  const fileData = await readUserFile(username)
+  if (fileData) {
+    const normalized = normalizeUser(fileData)
+    memoryStore.set(username, normalized)
+    return clone(normalized)
+  }
+  if (username === 'default') {
+    const tokens = await readLegacyTokens()
+    const normalized = {
+      password_hash: '',
+      tokens,
+      cod_username: '',
+      prestige: '',
+      level: 1,
+    }
+    memoryStore.set(username, normalized)
+    return clone(normalized)
+  }
+  return null
+}
+
+async function userExists(username) {
+  if (!username) return false
+  if (memoryStore.has(username)) return true
+  const userPath = path.join(DATA_DIR, `${username}.json`)
+  if (await fileExists(userPath)) return true
+  return false
+}
+
+async function saveUser(username, data) {
+  if (!username) return false
+  const normalized = normalizeUser(data)
+  memoryStore.set(username, normalized)
+  const userPath = path.join(DATA_DIR, `${username}.json`)
+  try {
+    await fs.mkdir(path.dirname(userPath), { recursive: true })
+  } catch (err) {
+    // ignore mkdir errors; writing will surface them
+  }
+  if (username === 'default') {
+    await writeLegacyTokens(normalized.tokens)
+  }
+  const payload = {
+    password_hash: normalized.password_hash,
+    tokens: normalized.tokens,
+    cod_username: normalized.cod_username,
+    prestige: normalized.prestige,
+    level: normalized.level,
+  }
+  try {
+    await fs.writeFile(userPath, JSON.stringify(payload, null, 2))
+    return true
+  } catch (err) {
+    if (err && (err.code === 'EROFS' || err.code === 'EACCES' || err.code === 'ENOSYS')) {
+      console.warn(`Non-persistent environment, user '${username}' changes kept in memory only.`)
+      return false
+    }
+    throw err
+  }
+}
+
+async function registerUser(username, password) {
+  const trimmed = typeof username === 'string' ? username.trim() : ''
+  if (!trimmed) {
+    const err = new Error('Username is required')
+    err.statusCode = 400
+    throw err
+  }
+  if (typeof password !== 'string' || password.length === 0) {
+    const err = new Error('Password is required')
+    err.statusCode = 400
+    throw err
+  }
+  if (await userExists(trimmed)) {
+    return false
+  }
+  const hash = await bcrypt.hash(password, 10)
+  const user = normalizeUser({
+    password_hash: hash,
+    tokens: zeroTokens(),
+    cod_username: '',
+    prestige: '',
+    level: 1,
+  })
+  await saveUser(trimmed, user)
+  return true
+}
+
+async function validateUser(username, password) {
+  const name = typeof username === 'string' ? username.trim() : ''
+  if (!name || typeof password !== 'string') {
+    return false
+  }
+  const user = await loadUser(name)
+  if (!user || !user.password_hash) {
+    return false
+  }
+  try {
+    return await bcrypt.compare(password, user.password_hash)
+  } catch (err) {
+    console.error('Failed to compare password for user', name, err)
+    return false
+  }
+}
+
+async function getTokens(username) {
+  const user = await loadUser(username)
+  if (!user) return null
+  return clone(user.tokens)
+}
+
+async function setTokens(username, tokens) {
+  const user = await loadUser(username)
+  if (!user) return false
+  user.tokens = normalizeTokens(tokens)
+  await saveUser(username, user)
+  return true
+}
+
+async function getProfile(username) {
+  const user = await loadUser(username)
+  if (!user) return null
+  return {
+    cod_username: user.cod_username,
+    prestige: user.prestige,
+    level: user.level,
+  }
+}
+
+async function updateProfile(username, profile) {
+  const user = await loadUser(username)
+  if (!user) return false
+  user.cod_username = typeof profile.cod_username === 'string' ? profile.cod_username : ''
+  user.prestige = typeof profile.prestige === 'string' ? profile.prestige : ''
+  user.level = clampLevel(profile.level ?? user.level)
+  await saveUser(username, user)
+  return true
+}
+
+module.exports = {
+  CATEGORIES,
+  MINUTE_BUCKETS,
+  loadUser,
+  userExists,
+  saveUser,
+  registerUser,
+  validateUser,
+  getTokens,
+  setTokens,
+  getProfile,
+  updateProfile,
+}

--- a/api/_lib/http.js
+++ b/api/_lib/http.js
@@ -1,0 +1,62 @@
+const { STATUS_CODES } = require('http')
+
+function setCors(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,OPTIONS')
+}
+
+async function readJson(req) {
+  const chunks = []
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  }
+  const raw = Buffer.concat(chunks).toString('utf8').trim()
+  if (!raw) return {}
+  try {
+    return JSON.parse(raw)
+  } catch (err) {
+    const error = new Error('Invalid JSON body')
+    error.statusCode = 400
+    throw error
+  }
+}
+
+function sendJson(res, statusCode, payload) {
+  res.statusCode = statusCode
+  res.setHeader('Content-Type', 'application/json; charset=utf-8')
+  res.end(JSON.stringify(payload))
+}
+
+function sendStatus(res, statusCode, message) {
+  res.statusCode = statusCode
+  if (message) {
+    res.setHeader('Content-Type', 'application/json; charset=utf-8')
+    res.end(JSON.stringify({ error: message }))
+  } else {
+    res.end()
+  }
+}
+
+function methodNotAllowed(res, allowed) {
+  res.setHeader('Allow', allowed.join(', '))
+  sendStatus(res, 405, 'Method Not Allowed')
+}
+
+function handleError(res, err) {
+  if (err && typeof err.statusCode === 'number') {
+    sendStatus(res, err.statusCode, err.message)
+  } else {
+    console.error(err)
+    sendStatus(res, 500, STATUS_CODES[500])
+  }
+}
+
+module.exports = {
+  setCors,
+  readJson,
+  sendJson,
+  sendStatus,
+  methodNotAllowed,
+  handleError,
+}

--- a/api/login.js
+++ b/api/login.js
@@ -1,0 +1,34 @@
+const { setCors, readJson, sendJson, sendStatus, methodNotAllowed, handleError } = require('./_lib/http')
+const { issueToken } = require('./_lib/auth')
+const { validateUser } = require('./_lib/data')
+
+module.exports = async (req, res) => {
+  setCors(res)
+  if (req.method === 'OPTIONS') {
+    res.setHeader('Allow', 'POST, OPTIONS')
+    sendStatus(res, 204)
+    return
+  }
+  if (req.method !== 'POST') {
+    methodNotAllowed(res, ['POST', 'OPTIONS'])
+    return
+  }
+  try {
+    const body = await readJson(req)
+    const username = typeof body.username === 'string' ? body.username.trim() : ''
+    const password = typeof body.password === 'string' ? body.password : ''
+    if (!username || !password) {
+      sendStatus(res, 400, 'Username and password are required')
+      return
+    }
+    const ok = await validateUser(username, password)
+    if (!ok) {
+      sendStatus(res, 401, 'Unauthorized')
+      return
+    }
+    const token = issueToken(username)
+    sendJson(res, 200, { token })
+  } catch (err) {
+    handleError(res, err)
+  }
+}

--- a/api/profile.js
+++ b/api/profile.js
@@ -1,0 +1,42 @@
+const { setCors, readJson, sendJson, sendStatus, methodNotAllowed, handleError } = require('./_lib/http')
+const { requireUser } = require('./_lib/auth')
+const { getProfile, updateProfile } = require('./_lib/data')
+
+module.exports = async (req, res) => {
+  setCors(res)
+  if (req.method === 'OPTIONS') {
+    res.setHeader('Allow', 'GET, PUT, OPTIONS')
+    sendStatus(res, 204)
+    return
+  }
+  if (req.method !== 'GET' && req.method !== 'PUT') {
+    methodNotAllowed(res, ['GET', 'PUT', 'OPTIONS'])
+    return
+  }
+  const username = requireUser(req, res)
+  if (!username) return
+  try {
+    if (req.method === 'GET') {
+      const profile = await getProfile(username)
+      if (!profile) {
+        sendStatus(res, 404, 'User not found')
+        return
+      }
+      sendJson(res, 200, profile)
+      return
+    }
+    const body = await readJson(req)
+    if (!body || typeof body !== 'object') {
+      sendStatus(res, 400, 'Invalid payload')
+      return
+    }
+    const ok = await updateProfile(username, body)
+    if (!ok) {
+      sendStatus(res, 404, 'User not found')
+      return
+    }
+    sendStatus(res, 204)
+  } catch (err) {
+    handleError(res, err)
+  }
+}

--- a/api/register.js
+++ b/api/register.js
@@ -1,0 +1,34 @@
+const { setCors, readJson, sendJson, sendStatus, methodNotAllowed, handleError } = require('./_lib/http')
+const { issueToken } = require('./_lib/auth')
+const { registerUser } = require('./_lib/data')
+
+module.exports = async (req, res) => {
+  setCors(res)
+  if (req.method === 'OPTIONS') {
+    res.setHeader('Allow', 'POST, OPTIONS')
+    sendStatus(res, 204)
+    return
+  }
+  if (req.method !== 'POST') {
+    methodNotAllowed(res, ['POST', 'OPTIONS'])
+    return
+  }
+  try {
+    const body = await readJson(req)
+    const username = typeof body.username === 'string' ? body.username.trim() : ''
+    const password = typeof body.password === 'string' ? body.password : ''
+    if (!username || !password) {
+      sendStatus(res, 400, 'Username and password are required')
+      return
+    }
+    const created = await registerUser(username, password)
+    if (!created) {
+      sendStatus(res, 409, 'User already exists')
+      return
+    }
+    const token = issueToken(username)
+    sendJson(res, 201, { token })
+  } catch (err) {
+    handleError(res, err)
+  }
+}

--- a/api/tokens.js
+++ b/api/tokens.js
@@ -1,0 +1,42 @@
+const { setCors, readJson, sendJson, sendStatus, methodNotAllowed, handleError } = require('./_lib/http')
+const { requireUser } = require('./_lib/auth')
+const { getTokens, setTokens } = require('./_lib/data')
+
+module.exports = async (req, res) => {
+  setCors(res)
+  if (req.method === 'OPTIONS') {
+    res.setHeader('Allow', 'GET, PUT, OPTIONS')
+    sendStatus(res, 204)
+    return
+  }
+  if (req.method !== 'GET' && req.method !== 'PUT') {
+    methodNotAllowed(res, ['GET', 'PUT', 'OPTIONS'])
+    return
+  }
+  const username = requireUser(req, res)
+  if (!username) return
+  try {
+    if (req.method === 'GET') {
+      const tokens = await getTokens(username)
+      if (!tokens) {
+        sendStatus(res, 404, 'User not found')
+        return
+      }
+      sendJson(res, 200, tokens)
+      return
+    }
+    const body = await readJson(req)
+    if (!body || typeof body !== 'object') {
+      sendStatus(res, 400, 'Invalid payload')
+      return
+    }
+    const ok = await setTokens(username, body)
+    if (!ok) {
+      sendStatus(res, 404, 'User not found')
+      return
+    }
+    sendStatus(res, 204)
+  } catch (err) {
+    handleError(res, err)
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,160 @@
+{
+  "name": "codxp-vercel",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "codxp-vercel",
+      "version": "1.0.0",
+      "dependencies": {
+        "bcryptjs": "^2.4.3",
+        "jsonwebtoken": "^9.0.2"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "codxp-vercel",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "build": "npm run build --prefix frontend"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.2"
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,19 @@
+{
+  "framework": "vite",
+  "installCommand": "npm install && npm install --prefix frontend",
+  "buildCommand": "npm run build --prefix frontend",
+  "outputDirectory": "frontend/dist",
+  "functions": {
+    "api/**/*.js": {
+      "runtime": "nodejs18.x",
+      "includeFiles": [
+        "data/**",
+        "tokens.txt"
+      ]
+    }
+  },
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/.*", "dest": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Node serverless functions for login, register, profile, and token routes backed by the existing JSON data directory
- share authentication and storage helpers that normalize user data and fall back to the legacy tokens.txt file when needed
- configure the Vercel build to install root dependencies, bundle the data directory with the functions, and add the required Node packages

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68cac61909ec832d817cf1d67b719e73